### PR TITLE
Remove space in ' Sweet Tea' beverage name

### DIFF
--- a/src/Provider/en_US/Restaurant.php
+++ b/src/Provider/en_US/Restaurant.php
@@ -13,7 +13,7 @@ class Restaurant extends \Faker\Provider\Base
 
     protected static $beverageNames = [
         'Beer', 'Bud Light', 'Budweiser', 'Miller Lite',
-        'Milk Shake', 'Tea', ' Sweet Tea', 'Coffee', 'Hot Tea',
+        'Milk Shake', 'Tea', 'Sweet Tea', 'Coffee', 'Hot Tea',
         'Champagne', 'Wine', 'Lemonade', 'Coca-Cola', 'Diet Coke',
         'Water', 'Sprite', 'Orange Juice', 'Iced Coffee'
     ];


### PR DESCRIPTION
Presume this is just a typo.

Models seeded to the database with beverage names can't be sorted correctly - ' Sweet Tea' comes before 'Beer' because of the space.