### PR TITLE
bugfix JP locale method names, updated faker dependency, added tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FakerRestaurant
 =======================
 
-Food and Beverage names generate using fzaninotto/Faker
+Food and Beverage names generate using fakerphp/faker (previously fzaninotto/Faker).
 
 
 Installation
@@ -16,7 +16,7 @@ composer require jzonta/faker-restaurant
 Usage
 -----
 
-To  use this with [Faker](https://github.com/fzaninotto/Faker), you must add the `FakerRestaurant\Restaurant` class to the Faker generator:
+To  use this with [Faker](https://github.com/fakerphp/Faker), you must add the `FakerRestaurant\Restaurant` provider class to the Faker generator:
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ar_SA -> \FakerRestaurant\Provider\ar_SA\Restaurant
 de_AT -> \FakerRestaurant\Provider\de_AT\Restaurant
 de_DE -> \FakerRestaurant\Provider\de_DE\Restaurant
 en_US -> \FakerRestaurant\Provider\en_US\Restaurant
-es_PE -> \FakerRestaurant\Provider\es_PE\Restaurant 
+es_PE -> \FakerRestaurant\Provider\es_PE\Restaurant
 fa_IR -> \FakerRestaurant\Provider\fa_IR\Restaurant
 fr_FR -> \FakerRestaurant\Provider\fr_FR\Restaurant
 id_ID -> \FakerRestaurant\Provider\id_ID\Restaurant
@@ -52,4 +52,125 @@ lt_LT -> \FakerRestaurant\Provider\lt_LT\Restaurant
 pt_BR -> \FakerRestaurant\Provider\pt_BR\Restaurant
 sv_SE -> \FakerRestaurant\Provider\sv_SE\Restaurant
 vi_VN -> \FakerRestaurant\Provider\vi_VN\Restaurant
+```
+
+Testing
+-----
+```sh
+composer run test
+### or ###
+php test/_all.php
+```
+Sample test results:
+```log
+> php test/_all.php
+
+====== Printing random beverage...
+[ar_SA] شاي ساخن
+[de_AT] Kaffee
+[de_DE] Eiskaffee
+[en_US] Sweet Tea
+[es_PE] Frutillada
+[fa_IR] آب
+[fr_FR] Coca-Cola
+[id_ID] Coca-Cola
+[it_IT] Milk Shake
+[ja_JP] サッポロ
+[lt_LT] Sultys
+[pt_BR] Suco de Abacaxi
+[sv_SE] Pripps Blå
+[vi_VN] Nước lọc
+====== Printing random dairy...
+[ar_SA] حليب
+[de_AT] Joghurt
+[de_DE] Mozzarella
+[en_US] Custard
+[es_PE] Queso
+[fa_IR] پنیر موتزارلا
+[fr_FR] Crème
+[id_ID] Mentega
+[it_IT] Crema pasticcera
+[ja_JP] モッツァレラ
+[lt_LT] Jogurtas
+[pt_BR] Iogurte
+[sv_SE] Yogurt
+[vi_VN] Sữa
+====== Printing random food...
+[ar_SA] نقانق لحم خنزير بالجبنة
+[de_AT] Saumaise
+[de_DE] Rinderrouladen
+[en_US] Cheese Dog
+[es_PE] Lentejas con arroz
+[fa_IR] ساندویچ سبزیجات
+[fr_FR] Boeuf Bourguignons
+[id_ID] Tahu Sumedang
+[it_IT] Tiramisù
+[ja_JP] 寿司
+[lt_LT] Dorada
+[pt_BR] X-Calabresa
+[sv_SE] Ärtsoppa
+[vi_VN] Mì
+====== Printing random fruit...
+[ar_SA] بلاك بيري
+[de_AT] Erdbeere
+[de_DE] Apfel
+[en_US] Pear
+[es_PE] Naranja
+[fa_IR] لیمو ترش
+[fr_FR] Pastèque
+[id_ID] Kismis
+[it_IT] Kiwi
+[ja_JP] ココナッツ
+[lt_LT] Gvajava
+[pt_BR] Kiwi
+[sv_SE] Kiwi
+[vi_VN] Dâu
+====== Printing random meat...
+[ar_SA] سجق
+[de_AT] Rindfleisch
+[de_DE] Schinken
+[en_US] Pork
+[es_PE] Pavo
+[fa_IR] ژامبون (گوشت خوک)
+[fr_FR] Boeuf
+[id_ID] Sayap Ayam
+[it_IT] Petto di tacchino
+[ja_JP] 子羊
+[lt_LT] Arkliena
+[pt_BR] Cachorro quente
+[sv_SE] Skinka
+[vi_VN] Ốc
+====== Printing random sauce...
+[ar_SA] صلصة الفلفل الحار
+[de_AT] Grillsauce
+[de_DE] Chillisauce
+[en_US] Chili sauce
+[es_PE] Mayonesa
+[fa_IR] سس سیر
+[fr_FR] Mayonaise
+[id_ID] Saus Tomat
+[it_IT] Salsa piccante
+[ja_JP] トマトペースト
+[lt_LT] Čili padažas
+[pt_BR] Molho de alho
+[sv_SE] Vitlökssås
+[vi_VN] Sốt mayonnaise
+====== Printing random vegetable...
+[ar_SA] بروكلي
+[de_AT] Rosmarie
+[de_DE] Ingwer
+[en_US] Carrot
+[es_PE] Papa
+[fa_IR] اسفناج
+[fr_FR] Menthe
+[id_ID] Bawang Bombay
+[it_IT] Rosmarino
+[ja_JP] にんじん
+[lt_LT] Brokolis
+[pt_BR] Pimentão
+[sv_SE] Mynta
+[vi_VN] Rau cải xoong
+
+
+====== THE END - ALL GOOD ======
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,13 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"FakerRestaurant\\": "src"
+			"FakerRestaurant\\": "src",
+			"Faker\\": "vendor/fakerphp/faker/src"
 		}
+	},
+	"scripts": {
+		"test": [
+			"php test/_all.php"
+		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "jzonta/faker-restaurant",
   "description": "Food and Beverage names generate using fzaninotto/Faker",
   "homepage": "https://github.com/jzonta/FakerRestaurant",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "license": "MIT",
   "authors": [
     { "name": "João Zonta" }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "jzonta/faker-restaurant",
 	"description": "Food and Beverage names generate using fakerphp/faker (previously fzaninotto/Faker)",
 	"homepage": "https://github.com/jzonta/FakerRestaurant",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"license": "MIT",
 	"authors": [{
 		"name": "João Zonta"

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,19 @@
 {
-  "name": "jzonta/faker-restaurant",
-  "description": "Food and Beverage names generate using fzaninotto/Faker",
-  "homepage": "https://github.com/jzonta/FakerRestaurant",
-  "version": "1.1.11",
-  "license": "MIT",
-  "authors": [
-    { "name": "João Zonta" }
-  ],
-  "require": {
-    "php": ">=5.4.0",
-    "fzaninotto/faker": "~1.4"
-  },
-  "autoload": {
-    "psr-4": {
-      "FakerRestaurant\\": "src"
-    }
-  }
+	"name": "jzonta/faker-restaurant",
+	"description": "Food and Beverage names generate using fakerphp/faker (previously fzaninotto/Faker)",
+	"homepage": "https://github.com/jzonta/FakerRestaurant",
+	"version": "2.0.0",
+	"license": "MIT",
+	"authors": [{
+		"name": "João Zonta"
+	}],
+	"require": {
+		"php": ">=5.4.0",
+		"fakerphp/faker": "^1.9.1"
+	},
+	"autoload": {
+		"psr-4": {
+			"FakerRestaurant\\": "src"
+		}
+	}
 }

--- a/src/Provider/ja_JP/Restaurant.php
+++ b/src/Provider/ja_JP/Restaurant.php
@@ -124,27 +124,27 @@ class Restaurant extends \Faker\Provider\Base
         return static::randomElement(static::$beverageNames);
     }
 
-    public function dairy()
+    public function dairyName()
     {
         return static::randomElement(static::$dairyNames);
     }
 
-    public function vegetable()
+    public function vegetableName()
     {
         return static::randomElement(static::$vegetableNames);
     }
 
-    public function fruit()
+    public function fruitName()
     {
         return static::randomElement(static::$fruitNames);
     }
 
-    public function meat()
+    public function meatName()
     {
         return static::randomElement(static::$meatNames);
     }
 
-    public function sauce()
+    public function sauceName()
     {
         return static::randomElement(static::$sauceNames);
     }

--- a/test/_all.php
+++ b/test/_all.php
@@ -1,0 +1,19 @@
+<?php
+
+try {
+	$fakersByLanguage = []; // array to cache faker instances, for faster garbage collection later
+	foreach (new DirectoryIterator(__DIR__) as $item) {
+		if (!$item->isDot() && $item->getFilename()[0] !== '_') { // all files except "." and those starting with "_"
+			require $item->getPathname(); // requiring those files ("food", "beverage", ecc) will then call the printer
+		}
+	}
+} catch (\Exception $e) {
+	print PHP_EOL . PHP_EOL . PHP_EOL . 'ERROR OCCURRED';
+	throw $e; // stop everything
+}
+
+
+print PHP_EOL . PHP_EOL . PHP_EOL . '====== THE END - ALL GOOD ======';
+
+
+//die;

--- a/test/_printer.php
+++ b/test/_printer.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php'; // require faker
+
+$dbbktr = \debug_backtrace();
+if (count($dbbktr) === 0) { // no incoming file to print
+	print PHP_EOL . '====== Nothing to print...';
+} else { // incoming file to print
+	$methodPrefix = \basename($dbbktr[0]['file'], '.php'); // what to print (eg "food")
+	$method = $methodPrefix . 'Name'; // method full name (eg "foodName")
+	print PHP_EOL . '====== Printing random ' . $methodPrefix . '...';
+
+	foreach (new DirectoryIterator(__DIR__ . '/../src/Provider/') as $item) { // FOREACH SUPPORTED LANGUAGE...
+		if ($item->isDot()) continue; // skip "."
+
+		$language = $item->getBasename(); // eg "it_IT"
+		$localizedClassName = "\\FakerRestaurant\\Provider\\${language}\\Restaurant"; // eg "\FakerRestaurant\Provider\it_IT\Restaurant"
+		/** @var \Faker\Generator */
+		$faker = $fakersByLanguage[$language] = $fakersByLanguage[$language] ?? new \Faker\Generator(); // get faker generator from cache array OR init a new one
+		if (!count($faker->getProviders())) { // add localized provider, if not already added
+			$faker->addProvider(new $localizedClassName($faker));
+		}
+		print PHP_EOL . "[${language}] " . $faker->$method(); // ...PRINT WHAT WAS REQUESTED
+	}
+}

--- a/test/beverage.php
+++ b/test/beverage.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';

--- a/test/dairy.php
+++ b/test/dairy.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';

--- a/test/food.php
+++ b/test/food.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';

--- a/test/fruit.php
+++ b/test/fruit.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';

--- a/test/meat.php
+++ b/test/meat.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';

--- a/test/sauce.php
+++ b/test/sauce.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';

--- a/test/vegetable.php
+++ b/test/vegetable.php
@@ -1,0 +1,4 @@
+<?php
+
+
+require '_printer.php';


### PR DESCRIPTION
Hi! I...
- fixed a few method names in the JP namespace
- updated faker dependency because `fzaninotto/faker` is deprecated; even Laravel itself now ships with the new dependency `phpfaker/faker` !
- added a simple test script (run `composer run test` to print some debug data using real Faker instances

---
have a nice day