### PR TITLE
Discard unmaintained version of faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "fzaninotto/faker": "~1.4"
+    "fakerphp/faker": "^1.9.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
### Why are we adding this??
fzaninotto/faker has been sunset according to: https://marmelab.com/blog/2020/10/21/sunsetting-faker.html

### How does this address the issue?
This PR updates composer.json to use [fakerphp](https://github.com/FakerPHP/Faker) which is a maintained fork of the original library. This update also allows for this project to be easily installed in laravel 8 projects.